### PR TITLE
[38기 김택수] 구매 및 판매입찰 / 즉시구매 / 포인트차감 및 추가 Transaction 구현

### DIFF
--- a/controllers/dealController.js
+++ b/controllers/dealController.js
@@ -1,0 +1,52 @@
+const dealService = require("../services/dealService");
+const { catchAsync } = require("../util/globalErrorHandler");
+
+const requestBuy = catchAsync(async (req, res, next) => {
+  const { productId, userId, price, totalPrice, sizeId } = req.body;
+
+  if (!productId || !userId || !price || !sizeId || !totalPrice) {
+    return res.status(400).json({ message: "KEY_ERROR" });
+  }
+
+  const data = await dealService.requestBuy(
+    productId,
+    userId,
+    price,
+    sizeId,
+    totalPrice
+  );
+
+  return await res.json({ message: data });
+});
+
+const requestSell = catchAsync(async (req, res, next) => {
+  const { productId, userId, price, sizeId, totalPrice } = req.body;
+
+  if (!productId || !userId || !price || !sizeId || !totalPrice) {
+    return res.status(400).json({ message: "KEY_ERROR" });
+  }
+
+  const data = await dealService.requestSell(
+    productId,
+    userId,
+    price,
+    sizeId,
+    totalPrice
+  );
+
+  return await res.json({ message: data });
+});
+
+const getProductInfo = catchAsync(async (req, res, next) => {
+  const { productId, userId } = req.params;
+
+  if (!productId || !userId) {
+    return res.status(400).json({ message: "KEY_ERROR" });
+  }
+
+  const data = await dealService.getProductInfo(productId, userId);
+
+  return await res.json({ message: data });
+});
+
+module.exports = { requestBuy, requestSell, getProductInfo };

--- a/controllers/testController.js
+++ b/controllers/testController.js
@@ -1,9 +1,0 @@
-const testService = require("../services/testService");
-const { catchAsync } = require("../util/globalErrorHandler");
-
-const test = catchAsync(async (req, res, next) => {
-  const data = await testService.test();
-  return await res.json({ message: data });
-});
-
-module.exports = { test };

--- a/models/dealDao.js
+++ b/models/dealDao.js
@@ -1,0 +1,180 @@
+const { krweamDataSource } = require("../util/dataSourceWrapperClass");
+
+const createBuy = async (productId, userId, price, totalPrice, sizeId) => {
+  const queryRunner = krweamDataSource.createQueryRunner();
+  try {
+    await queryRunner.connect();
+    await queryRunner.startTransaction();
+
+    const sellPriceData = await queryRunner.query(`
+    SELECT
+      bp.id AS sellPriceId,
+      bp.product_id AS sellProductId,
+      bp.user_id AS sellUserId,
+      bp.price AS sellPrice
+    FROM sell_prices AS bp
+    WHERE product_id = ${productId} AND price = ${price}
+    ORDER BY created_at ASC
+    LIMIT 1
+    `);
+
+    if (sellPriceData.length == 0) {
+      const data = await queryRunner.query(`
+      INSERT INTO buy_prices (
+        product_id,
+        user_id,
+        price
+      ) VALUE (
+        ${productId}, ${userId}, ${price}
+      )
+    `);
+      await queryRunner.commitTransaction();
+      await queryRunner.release();
+      return "ADD_SELLPRICE_DATA";
+    }
+
+    const { sellPriceId, sellProductId, sellUserId, sellPrice } =
+      sellPriceData[0];
+
+    const dealHistoriesRow = await queryRunner.query(
+      `
+      INSERT INTO deal_histories (sell_user_id, buy_user_id, product_id, price, size_id) VALUES (?,?,?,?,?)
+    `,
+      [sellUserId, userId, sellProductId, sellPrice, sizeId]
+    );
+
+    await queryRunner.query(`
+    DELETE FROM sell_prices WHERE id = ${sellPriceId}
+  `);
+
+    const sellerId = await queryRunner.query(`
+    SELECT sell_user_id FROM deal_histories WHERE id = ${dealHistoriesRow.insertId} LIMIT 1
+  `);
+
+    const buyerId = await queryRunner.query(`
+    SELECT buy_user_id FROM deal_histories WHERE id = ${dealHistoriesRow.insertId} LIMIT 1
+  `);
+
+    const sellerPoint = await queryRunner.query(`
+    UPDATE users SET point = point + ${sellPrice} WHERE id = ${sellerId[0].sell_user_id}
+  `);
+
+    const buyPoint = await queryRunner.query(`
+    UPDATE users SET point = point - ${totalPrice} WHERE id = ${buyerId[0].buy_user_id}
+  `);
+
+    await queryRunner.commitTransaction();
+    await queryRunner.release();
+
+    return "DEAL COMPLETE";
+  } catch (error) {
+    console.log(error.message);
+
+    await queryRunner.rollbackTransaction();
+    await queryRunner.release();
+
+    throw error;
+  }
+};
+
+const createSell = async (productId, userId, price, sizeId, totalPrice) => {
+  const queryRunner = krweamDataSource.createQueryRunner();
+  try {
+    await queryRunner.connect();
+    await queryRunner.startTransaction();
+
+    const buyPriceData = await queryRunner.query(`
+    SELECT
+      bp.id AS buyPriceId,
+      bp.product_id AS buyProductId,
+      bp.user_id AS buyUserId,
+      bp.price AS buyPrice
+    FROM buy_prices AS bp
+    WHERE product_id = ${productId} AND price = ${price}
+    ORDER BY created_at ASC
+    LIMIT 1
+    `);
+
+    if (buyPriceData.length == 0) {
+      const data = await queryRunner.query(`
+        INSERT INTO sell_prices (
+          product_id,
+          user_id,
+          price
+        ) VALUE (
+          ${productId}, ${userId}, ${price}
+        )
+      `);
+      await queryRunner.commitTransaction();
+      await queryRunner.release();
+      return "ADD_BUYPRICE_DATA";
+    }
+
+    const { buyPriceId, buyProductId, buyUserId, buyPrice } = buyPriceData[0];
+
+    const dealHistoriesRow = await queryRunner.query(
+      `
+        INSERT INTO deal_histories (sell_user_id, buy_user_id, product_id, price, size_id) VALUES (?,?,?,?,?)
+      `,
+      [buyUserId, userId, buyProductId, buyPrice, sizeId]
+    );
+
+    await queryRunner.query(`
+      DELETE FROM buy_prices WHERE id = ${buyPriceId}
+    `);
+
+    const sellerId = await queryRunner.query(`
+      SELECT sell_user_id FROM deal_histories WHERE id = ${dealHistoriesRow.insertId}
+    `);
+
+    const buyerId = await queryRunner.query(`
+      SELECT buy_user_id FROM deal_histories WHERE id = ${dealHistoriesRow.insertId}
+    `);
+
+    const sellerPoint = await queryRunner.query(`
+      UPDATE users SET point = point + ${buyPrice} WHERE id = ${sellerId[0].sell_user_id}
+    `);
+
+    const buyPoint = await queryRunner.query(`
+      UPDATE users SET point = point - ${totalPrice} WHERE id = ${buyerId[0].buy_user_id}
+    `);
+
+    await queryRunner.commitTransaction();
+    await queryRunner.release();
+
+    return "DEAL COMPLETE";
+  } catch (error) {
+    console.log(error);
+
+    await queryRunner.rollbackTransaction();
+    await queryRunner.release();
+
+    throw error;
+  }
+};
+
+const getProductInfo = async (productId, userId) => {
+  const data = await krweamDataSource.query(`
+    SELECT 
+    p.thumbnail AS productImage,
+    p.model_number AS modelNumber,
+    p.korean_name AS productKrName,
+    p.english_name AS productEngName,
+    p.category_id AS categoryId,
+    (SELECT sp.price FROM sell_prices AS sp WHERE sp.product_id = ${productId} ORDER BY sp.price ASC LIMIT 1) AS sellPrice,
+    (SELECT bp.price FROM buy_prices AS sp WHERE bp.product_id = ${productId} ORDER BY bp.price ASC LIMIT 1) AS buyPrice,
+    (SELECT u.point FROM users AS u WHERE u.id = ${userId}) as point
+    FROM products AS p
+    LEFT JOIN categories AS c ON p.category_id = c.id
+    LEFT JOIN buy_prices AS bp ON bp.product_id = p.id
+    LEFT JOIN sell_prices AS sp ON sp.product_id = p.id
+    WHERE p.id = ${productId}
+  `);
+  return data[0];
+};
+
+module.exports = {
+  createBuy,
+  createSell,
+  getProductInfo,
+};

--- a/models/testDao.js
+++ b/models/testDao.js
@@ -1,8 +1,0 @@
-const Database = require("../util/dataSourceWrapperClass");
-
-const test = async () => {
-  const test = "connect success";
-  return test;
-};
-
-module.exports = { test };

--- a/routers/dealRouter.js
+++ b/routers/dealRouter.js
@@ -1,0 +1,9 @@
+const dealController = require("../controllers/dealController");
+
+const router = require("express").Router();
+
+router.post("/buy", dealController.requestBuy);
+router.post("/sell", dealController.requestSell);
+router.get("/:productId/:userId", dealController.getProductInfo);
+
+module.exports = { router };

--- a/routers/index.js
+++ b/routers/index.js
@@ -1,6 +1,6 @@
 const router = require("express").Router();
-const testRouter = require("./testRouter");
+const dealRouter = require("./dealRouter");
 
-router.use("/test", testRouter.router);
+router.use("/deal", dealRouter.router);
 
 module.exports = router;

--- a/routers/testRouter.js
+++ b/routers/testRouter.js
@@ -1,7 +1,0 @@
-const testController = require("../controllers/testController");
-
-const router = require("express").Router();
-
-router.get("", testController.test);
-
-module.exports = { router };

--- a/services/dealService.js
+++ b/services/dealService.js
@@ -1,0 +1,15 @@
+const dealDao = require("../models/dealDao");
+
+const requestBuy = async (productId, userId, price, totalPrice, sizeId) => {
+  return await dealDao.createBuy(productId, userId, price, totalPrice, sizeId);
+};
+
+const requestSell = async (productId, userId, price, totalPrice, sizeId) => {
+  return await dealDao.createSell(productId, userId, price, totalPrice, sizeId);
+};
+
+const getProductInfo = async (productId, userId) => {
+  return await dealDao.getProductInfo(productId, userId);
+};
+
+module.exports = { requestBuy, requestSell, getProductInfo };

--- a/services/testService.js
+++ b/services/testService.js
@@ -1,7 +1,0 @@
-const testDao = require("../models/testDao");
-
-const test = async () => {
-  return await testDao.test();
-};
-
-module.exports = { test };

--- a/util/dataSourceWrapperClass.js
+++ b/util/dataSourceWrapperClass.js
@@ -7,7 +7,7 @@ class Database {
   async query(sql, params) {
     return await this.dataSource.query(sql, params);
   }
-};
+}
 
 const krweamDataSource = new DataSource({
   type: process.env.TYPEORM_CONNECTION,

--- a/util/globalErrorHandler.js
+++ b/util/globalErrorHandler.js
@@ -12,4 +12,7 @@ const globalErrorHandler = (err, req, res, next) => {
   res.status(err.statusCode).json({ message: err.message });
 };
 
-module.exports = { catchAsync, globalErrorHandler };
+module.exports = {
+  catchAsync,
+  globalErrorHandler,
+};


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- 구매 및 판매 관련 flow를 Transaction으로 구현
<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
1. 구매 flow
- 특정 상품 구매 시 같은 금액의 sell_prices table 데이터가 있는지 조회
- 같은 금액의 data 없으면 buy_prices table 에 productId와 price data를 추가
- 같은 금액의 data 있으면 deal_histories로 연결
- deal_histories(즉시구매내역)에 sell_user_id, buy_user_id, price_ sizeId 추가
- deal_histories의 insertId 받아와서 sellerId와 buyerId를 받을 수 있음
- 받은 후 user table에 접근하여 sellerId에 해당하는 user의 point를 price만큼 추가
- buyerId에 해당하는 user의 point를 price만큼 차감
- sell_prices(판매내역)에서 구매와 일치했던 데이터의 id를 받아와서 삭제
- 
2. 판매 flow
- 특정 상품 판매 시 같은 금액의 buy_prices table 데이터가 있는지 조회
- 같은 금액의 data 없으면 sell_prices table에 productId와 price data를 추가
- 같은 금액의 data 있으면 deal_histories table로 연결
- deal_histories(즉시구매내역)에 sell_user_id, buy_user_id, price_ sizeId 추가
- deal_histories의 insertId 받아와서 sellerId와 buyerId를 받을 수 있음
- 받은 후 user table에 접근하여 sellerId에 해당하는 user의 point를 price만큼 추가
- buyerId에 해당하는 user의 point를 price만큼 차감
- sell_prices(판매내역)에서 구매와 일치했던 데이터의 id를 받아와서 삭제

<br />

## :: 성장 포인트 (해당 기능을 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)
- Transaction 사용에 대한 감을 익힐 수 있었음. Transaction의 대략적 동작flow는 알고 있었으나 그 원리에 대해선 고민해보지 않은 점이 있었다. 그로 인헤 오류 상황이 발생 했었다.

1. queryRunner 사용 및 원리를 알게 됐음
  - Transaction의 구조는 try문 안에 로직들을 넣고 그 로직들에서 Error가 나면 catch문에서 error handling을 하는 구조로 잡았다. 그리고 Transaction의 가장 중요한 점인 rollback의 기능을 사용하기 위해서는 QueryRunner라는 기능을 사용해 Query문을 작성하여 하나의 flow로써 기능하게 해야하는데, 기존에 사용하던 Datasource를 그대로 사용한 Query문을 Transaction 안에서 사용하다보니 여러가지 Query문들이 하나의 flow가 아닌 그냥 독립적인 하나의 기능으로써 예를 들면, 플러그를 계속 꽂고 빼는 과정을 했기 때문에 DB에 그 Query문들이 바로 적용되었고, 결과적으로는 rollback의 기능을 사용할 수 없는 구조로 Transaction을 사용하고 있었다. 

2. Error 상황에서의 Handling 불가
  - Transaction의 try문 안에서 Error가 발생했을 때 당연히 자연스럽게 catch문으로 넘어가서 Error를 throw하고 GlobalErrorHandler가 작동한다고 생각하고 코드를 써갔는데, 결론적으로는 의도한대로 ErrorHandling이 되지 않았다. 그 이유는 1번의 원리와 비슷한데, 하나의 flow로 내려가는 try문에 계속 독립적인 기능을 하는 함수들이 작동해버렸기 때문에 하나의 Error로 인식하지 못했기 때문이라고 인지했다. (정확한지는 조금 더 공부해볼 예정) 그래서 추후에 함수 안에 있는 Query문들을 전부 Transaction 안으로 옮겨줬고, 기존 Service단에서 사용했던 것을 Dao단으로 옮겨서 사용하게 했다. 이후 ErrorHandler가 정상적으로 작동했다.

<br />

## :: 기타 질문 및 특이 사항
