### PR TITLE
[38기 김택수] ADD : 마이페이지 구매내역 및 판매내역 조회 완료

### DIFF
--- a/controllers/mypageController.js
+++ b/controllers/mypageController.js
@@ -1,0 +1,8 @@
+const mypageService = require("../services/mypageService");
+const { catchAsync } = require("../util/globalErrorHandler");
+
+const getDealHistories = catchAsync(async (req, res, next) => {
+  const data = await mypageService.getDealHistories(userId);
+  return await res.json({ message: data });
+});
+module.exports = { getDealHistories };

--- a/models/mypageDao.js
+++ b/models/mypageDao.js
@@ -1,0 +1,66 @@
+const { database } = require("../util/dataSourceWrapperClass");
+
+const getDealHistoriesBuyUser = async (userId) => {
+  return await database.query(`
+    SELECT 
+    dh.product_id AS productId,
+    dh.size_id AS sizeId,
+    p.english_name AS productEngName,
+    p.thumbnail AS productImage,
+    dh.price AS buyPrice,
+    dh.created_at AS created
+    FROM deal_histories AS dh
+    LEFT JOIN products AS p ON dh.product_id = p.id
+    WHERE dh.buy_user_id = ${userId}
+  `);
+};
+
+const getBuyPricesUser = async (userId) => {
+  return await database.query(`
+  SELECT 
+  bp.product_id AS productId,
+  p.english_name AS productEngName,
+  p.thumbnail AS productImage,
+  bp.price AS buyPrice,
+  bp.created_at AS created
+  FROM buy_prices AS bp
+  LEFT JOIN products AS p ON bp.product_id = p.id
+  WHERE bp.user_id = ${userId}
+  `);
+};
+
+const getDealHistoriesSellUser = async (userId) => {
+  return await database.query(`
+    SELECT 
+    dh.product_id AS productId,
+    dh.size_id AS sizeId,
+    p.english_name AS productEngName,
+    p.thumbnail AS productImage,
+    dh.price AS buyPrice,
+    dh.created_at AS created
+    FROM deal_histories AS dh
+    LEFT JOIN products AS p ON dh.product_id = p.id
+    WHERE dh.sell_user_id = ${userId}
+  `);
+};
+
+const getSellPricesUser = async (userId) => {
+  return await database.query(`
+  SELECT 
+  sp.product_id AS productId,
+  p.english_name AS productEngName,
+  p.thumbnail AS productImage,
+  sp.price AS sellPrice,
+  sp.created_at AS created
+  FROM sell_prices AS sp
+  LEFT JOIN products AS p ON sp.product_id = p.id
+  WHERE sp.user_id = ${userId}
+  `);
+};
+
+module.exports = {
+  getBuyPricesUser,
+  getDealHistoriesBuyUser,
+  getDealHistoriesSellUser,
+  getSellPricesUser,
+};

--- a/routers/mypageRouter.js
+++ b/routers/mypageRouter.js
@@ -1,0 +1,7 @@
+const mypageController = require("../controllers/mypageController");
+
+const router = require("express").Router();
+
+router.get("", mypageController.getDealHistories);
+
+module.exports = { router };

--- a/services/mypageService.js
+++ b/services/mypageService.js
@@ -1,0 +1,43 @@
+const mypageDao = require("../models/mypageDao");
+
+const getDealHistories = async (userId) => {
+  const completeBuyDealHistories = await mypageDao.getDealHistoriesBuyUser(
+    userId
+  );
+  const currentDealBuyHistories = await mypageDao.getBuyPricesUser(userId);
+  const completeDealSellHistories = await mypageDao.getDealHistoriesSellUser(
+    userId
+  );
+  const currentDealSellHistories = await mypageDao.getSellPricesUser(userId);
+
+  const result = [
+    {
+      buy: [
+        {
+          status: "입찰 중",
+          productList: currentDealBuyHistories,
+        },
+        { status: "진행 중" },
+        {
+          status: "결제완료",
+          productList: completeBuyDealHistories,
+        },
+      ],
+      sell: [
+        {
+          status: "입찰 중",
+          productList: currentDealSellHistories,
+        },
+        { status: "진행 중" },
+        {
+          status: "결제완료",
+          productList: completeDealSellHistories,
+        },
+      ],
+    },
+  ];
+
+  return result;
+};
+
+module.exports = { getDealHistories };


### PR DESCRIPTION
- 프론트엔드에서 데이터구조 요청한 부분들 반영완료

## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- 마이페이지 내 구매 및 판매내역 데이터 반환기능 구현

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
1. 구매내역 반환
- 현재 크림에는 구매입찰, 구매완료 두 가지 상태가 존재하며, 두 개의 테이블에서 구매유저로 등록되어있는 id값을 찾아 데이터를 반환한다. (product 정보)

2. 판매내역 반환
- 판매 또한 판매입찰, 판매완료 두 가지 상태이며, 똑같이 product 정보를 반환한다.

3. 데이터 구조 변경
- 프론트엔드에서 요청한 데이터구조대로 변경하여 반환할 수 있도록 service단에서 데이터 구조 변경

<br />

## :: 성장 포인트 (해당 기능을 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)

<br />

## :: 기타 질문 및 특이 사항
